### PR TITLE
updated papaparse to deal with UTF-8 with BOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fs-extra": "^10.0.0",
     "jszip": "^3.7.1",
     "mime-types": "^2.1.34",
-    "papaparse": "^5.3.1",
+    "papaparse": "^5.4.0",
     "ts-node": "^10.4.0",
     "tslint": "^5.20.1",
     "typescript": "^4.5.5",


### PR DESCRIPTION
h5p-cli-creator was creating malformed H5P when fed a CSV that was encoded in UTF-8 with a byte-order mark. The papaparse dependency was to blame, but there is a fix upstream and this includes it.